### PR TITLE
feat(proxier): change core datamodel to be based around services

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ A no-frills local development approach for Kubernetes powered Developer Environm
 
 ## Why another CLI tool?
 
-Tools such as; Telepresence, Skaffold, and Tilt all attempt to solve the problem of getting users
+Tools such as; Telepresence, Skaffold, and others all attempt to solve the problem of getting users
 used to using Kubernetes. This is a pretty big task given that Kubernetes has a gigantic surface
 area. From my experience (**keyword**: _my experience_), developers have no interest in what
-platform they are deploying to. All they care about is it's easy to do and that local development is
-not complicated or different from what they are used to. I, also, firmly belive that the best dev-tool is
+platform they are deploying to. All they care about is it's easy to work with and that local development is
+not complicated or different from what they are used to. I, also, firmly believe that the best dev-tool is
 a tool that requires no configuration, and is self-explanatory. Which these tools tend... to not be.
 
 Given the above, localizer attempts to solve this problem with a few rules:
@@ -22,7 +22,7 @@ they were running "locally" (**Note**: Only on Linux do containers _actually_ ru
 
 Given the context of why this was created, and the constraints listed therein, localizer solves these issues
 by emulating services running locally. It, essentially, can be considered a fancy wrapper around `kubectl port-forward`
-in it's basic operation. Services in a cluster are automatically discovered and port-forwards are created. While running
+in it's basic operation. Services in a cluster are automatically discovered and tunnels are created. While running
 an entry will be added to your local dns resolver that will also allow the service to be looked up by its Kubernetes
 service name. This allows a thin emulation layer of Kubernetes, without the caveats of a real Kubernetes cluster.
 
@@ -38,24 +38,17 @@ When running `localizer expose <serviceName>` your local machine will look for a
 Kubernetes cluster, and if it exists it will create a container that will proxy traffic sent to it to your local machine
 allowing remote resources to access your local machine as if they were also running locally.
 
-
-## How do run `localizer`?
+## How do I run `localizer`?
 
 Easy, just download a release from [Github Releases](/releases) and run the following:
 
 ```
-$ localizer
+$ sudo localizer
 ```
 
 This will attempt to proxy all services in Kubernetes to your local machine under their respective ports.
 
 ## FAQ
-
-### Help! I have a port-collision, what do I do?
-
-The downside to local development is this happens :( However, we have a way to "change" the port that is exposed locally.
-Simply add a `localizer.jaredallard.github.com/remap-servicePortName: "localPort"` annotation to the service, and that port 
-will be mapped to `localPort` instead of `servicePort` when `localizer` is run
 
 ### Does `localizer` support Windows?
 

--- a/cmd/localizer/localizer.go
+++ b/cmd/localizer/localizer.go
@@ -211,7 +211,7 @@ func main() { //nolint:funlen,gocyclo
 
 					p, err := e.Expose(ctx, mappedServicePorts, serviceSplit[0], serviceSplit[1])
 					if err != nil {
-						return errors.Wrap(err, "failed to create reverse port-forward")
+						return errors.Wrap(err, "failed to create reverse tunnel")
 					}
 
 					return p.Start(ctx)

--- a/internal/expose/port.go
+++ b/internal/expose/port.go
@@ -58,7 +58,7 @@ func (s *scaledObjectType) GetKey() string {
 }
 
 func (p *ServiceForward) createServerPortForward(ctx context.Context, po *corev1.Pod) (*portforward.PortForwarder, error) {
-	return kube.CreatePortForward(ctx, p.c.k.CoreV1().RESTClient(), p.c.kconf, po, "0.0.0.0", "50:50")
+	return kube.CreatePortForward(ctx, p.c.k.CoreV1().RESTClient(), p.c.kconf, po, "0.0.0.0", []string{"50:50"})
 }
 
 func (p *ServiceForward) createServerPodAndTransport(ctx context.Context) (func(), error) { //nolint:funlen,gocyclo
@@ -158,11 +158,11 @@ loop:
 		}
 	}
 
-	p.c.log.Info("pod is ready, creating port-forward(s)")
+	p.c.log.Info("pod is ready, creating tunnel")
 
 	fw, err := p.createServerPortForward(ctx, po)
 	if err != nil {
-		return func() {}, errors.Wrap(err, "failed to create port-forward for underlying transport")
+		return func() {}, errors.Wrap(err, "failed to create tunnel for underlying transport")
 	}
 
 	fw.Ready = make(chan struct{})

--- a/internal/kube/client.go
+++ b/internal/kube/client.go
@@ -69,7 +69,7 @@ func GetKubeClient(contextName string) (*rest.Config, kubernetes.Interface, erro
 }
 
 func CreatePortForward(ctx context.Context, r rest.Interface, rc *rest.Config,
-	p *corev1.Pod, ip, port string) (*portforward.PortForwarder, error) {
+	p *corev1.Pod, ip string, ports []string) (*portforward.PortForwarder, error) {
 	req := r.Post().
 		Resource("pods").
 		Namespace(p.Namespace).
@@ -82,7 +82,7 @@ func CreatePortForward(ctx context.Context, r rest.Interface, rc *rest.Config,
 	}
 	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, "POST", req.URL())
 
-	return portforward.NewOnAddresses(dialer, []string{ip}, []string{port}, ctx.Done(), nil, ioutil.Discard, ioutil.Discard)
+	return portforward.NewOnAddresses(dialer, []string{ip}, ports, ctx.Done(), nil, ioutil.Discard, ioutil.Discard)
 }
 
 type ResolvedServicePort struct {


### PR DESCRIPTION
**What this PR does**: This PR changes the core code of the main proxier mode to be service-oriented. This also changes the language from port-forward(s) to tunnel, to reflect the more holistic tunnel that it creates now. This also moves tunnels to be created in parallel, which dramatically speeds up the first run, and due to having one proxy per service there are now less connections to create