### PR TITLE
fix(proxier): allocate IPs on ProxyConnection Start(), free on Close()

### DIFF
--- a/internal/proxier/proxy.go
+++ b/internal/proxier/proxy.go
@@ -396,10 +396,11 @@ func (p *Proxier) Proxy(ctx context.Context) error {
 	p.log.Info("cleaning up ...")
 
 	p.connMutex.Lock()
-	for _, pc := range p.activeServices {
+	for k, pc := range p.activeServices {
 		if err := pc.Close(); err != nil {
-			p.log.WithField("service", pc.Service.GetKey()).WithError(err).Debug("failed to close proxy connection")
+			p.log.WithField("service", k).WithError(err).Debug("failed to close proxy connection")
 		}
+		p.activeServices[k] = nil
 	}
 	p.connMutex.Unlock()
 


### PR DESCRIPTION
**What this PR does**: This change moves the IP allocation and DNS writing to ProxyConnection to prevent duplicate allocation, but also to allow for IPs / DNS entries to be free'd as services are removed and pods are refreshed.
