### PR TITLE
feat(expose): add serviceName to expose's pod generateName

### DIFF
--- a/internal/expose/client.go
+++ b/internal/expose/client.go
@@ -315,10 +315,11 @@ func (c *Client) Expose(ctx context.Context, ports []kube.ResolvedServicePort, n
 	}
 
 	return &ServiceForward{
-		c:         c,
-		Namespace: namespace,
-		Selector:  s.Spec.Selector,
-		Ports:     ports,
-		objects:   objects,
+		c:           c,
+		ServiceName: serviceName,
+		Namespace:   namespace,
+		Selector:    s.Spec.Selector,
+		Ports:       ports,
+		objects:     objects,
 	}, nil
 }

--- a/internal/expose/port.go
+++ b/internal/expose/port.go
@@ -35,9 +35,10 @@ import (
 type ServiceForward struct {
 	c *Client
 
-	Namespace string
-	Selector  map[string]string
-	Ports     []kube.ResolvedServicePort
+	ServiceName string
+	Namespace   string
+	Selector    map[string]string
+	Ports       []kube.ResolvedServicePort
 
 	// TODO(jaredallard): support replacing non associated pods?
 	objects map[string]scaledObjectType
@@ -83,7 +84,7 @@ func (p *ServiceForward) createServerPodAndTransport(ctx context.Context) (clean
 	podObject := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:    p.Namespace,
-			GenerateName: "localizer-",
+			GenerateName: fmt.Sprintf("localizer-%s", p.ServiceName),
 			Annotations: map[string]string{
 				proxier.ExposedAnnotation:          "true",
 				proxier.ExposedLocalPortAnnotation: string(exposedPortsJSON),


### PR DESCRIPTION
**What this PR does**: This PR sets expose's generateName to include the name of the service we're tunneling. This implements #15.
