### PR TITLE
fix(expose): add debugging information for when ssh tunnel transport dies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/function61/gokit v0.0.0-20200923114939-f8d7e065a5c3
 	github.com/go-logr/logr v0.3.0
 	github.com/golang/protobuf v1.4.3
-	github.com/imdario/mergo v0.3.8
+	github.com/imdario/mergo v0.3.8 // indirect
 	github.com/metal-stack/go-ipam v1.7.0
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.7.0

--- a/internal/expose/port.go
+++ b/internal/expose/port.go
@@ -218,7 +218,10 @@ func (p *ServiceForward) createTransport(ctx context.Context, po *corev1.Pod, lo
 	fw.Ready = make(chan struct{})
 
 	//nolint:errcheck
-	go fw.ForwardPorts()
+	go func() {
+		err := fw.ForwardPorts()
+		p.c.log.WithField("pod", po.Namespace+"/"+po.Name).WithError(err).Warn("underlying transport for ssh tunnel died, this requires a restart")
+	}()
 
 	p.c.log.Debug("waiting for transport to be marked as ready")
 	select {


### PR DESCRIPTION
**What this PR does**: This PR adds more debugging info for when the underlying `expose` ssh tunnel transport dies, also helps the user a little bit, but this is just a stop-gap.
