### PR TITLE
fix release link, and sudo instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ allowing remote resources to access your local machine as if they were also runn
 
 ## How do I run `localizer`?
 
-Easy, just download a release from [Github Releases](/releases) and run the following:
+Easy, just download a release from [Github Releases](../../releases/latest) and run the following:
 
 ```
-$ sudo localizer
+$ sudo -E localizer
 ```
 
 This will attempt to proxy all services in Kubernetes to your local machine under their respective ports.


### PR DESCRIPTION
Release link is broken as links rendered from README.md will include `blob/master`

##  sudo

When I run `sudo localizer`, seemingly it ignored my KUBECONFIG env variable. I made sure it was exported, still no cigar.
I found the explicit mention of respecting KUBECONFIG [in the source](https://github.com/jaredallard/localizer/blob/master/cmd/localizer/localizer.go#L111), so I finally figured, that sudo is not inheriting (even exported) env vars.

Unless you add the `-E` parameter.
