### PR TITLE
Fix kubecontext selection for localizer command

### DIFF
--- a/cmd/localizer/localizer.go
+++ b/cmd/localizer/localizer.go
@@ -124,10 +124,11 @@ func main() { //nolint:funlen,gocyclo
 			klog.SetLogger(&kube.KlogtoLogrus{Log: log.WithField("logger", "klog")})
 
 			// setup the global kubernetes cache interface
-			_, k, err := kube.GetKubeClient("")
+			config, k, err := kube.GetKubeClient(c.String("context"))
 			if err != nil {
 				return err
 			}
+			log.Infof("using apiserver %s", config.Host)
 			kevents.ConfigureGlobalCache(k)
 
 			return nil
@@ -151,6 +152,7 @@ func main() { //nolint:funlen,gocyclo
 			srv := server.NewGRPCService(&server.RunOpts{
 				ClusterDomain: clusterDomain,
 				IPCidr:        ipCidr,
+				KubeContext:   c.String("context"),
 			})
 			return srv.Run(ctx, log)
 		},

--- a/internal/kube/client.go
+++ b/internal/kube/client.go
@@ -42,19 +42,13 @@ func GetKubeClient(contextName string) (*rest.Config, kubernetes.Interface, erro
 	config, err := rest.InClusterConfig()
 	if err != nil {
 		lr := clientcmd.NewDefaultClientConfigLoadingRules()
-		apiconfig, err := lr.Load()
-		if err != nil {
-			return nil, nil, err
-		}
 
 		overrides := &clientcmd.ConfigOverrides{}
 		if contextName != "" {
 			overrides.CurrentContext = contextName
 		}
 
-		ccc := clientcmd.NewDefaultClientConfig(*apiconfig, overrides)
-
-		config, err = ccc.ClientConfig()
+		config, err = clientcmd.NewNonInteractiveDeferredLoadingClientConfig(lr, overrides).ClientConfig()
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "failed to get kubernetes client config")
 		}

--- a/internal/server/grpc.go
+++ b/internal/server/grpc.go
@@ -39,6 +39,7 @@ type GRPCService struct {
 type RunOpts struct {
 	ClusterDomain string
 	IPCidr        string
+	KubeContext   string
 }
 
 func NewGRPCService(opts *RunOpts) *GRPCService {

--- a/internal/server/grpc_server.go
+++ b/internal/server/grpc_server.go
@@ -52,7 +52,7 @@ func NewServiceHandler(ctx context.Context, log logrus.FieldLogger, opts *RunOpt
 	log = log.WithField("service", "*api.GRPCServiceHandler")
 
 	// TODO: pass context
-	kconf, k, err := kube.GetKubeClient("")
+	kconf, k, err := kube.GetKubeClient(opts.KubeContext)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create kube client")
 	}


### PR DESCRIPTION
turns out that localised didn't work if you did not have a `current-context` set in your kubeconfig (which I don't).

This PR fixes the already present `--context` flag that was not really used so far.