### PR TITLE
Fix service additions while localizer is running.

### DIFF
--- a/internal/kevents/cache.go
+++ b/internal/kevents/cache.go
@@ -10,8 +10,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
-
-	corev1 "k8s.io/api/core/v1"
 )
 
 // GlobalCache is an optional global cache that can be initialized
@@ -86,7 +84,7 @@ func (c *Cache) TrackObject(resourceName string, obj runtime.Object) cache.Contr
 
 	objStore, objInformer := cache.NewInformer(
 		cache.NewListWatchFromClient(c.k.CoreV1().RESTClient(), resourceName, c.namespace, fields.Everything()),
-		&corev1.Endpoints{},
+		obj,
 		time.Second*60,
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {

--- a/internal/kube/client.go
+++ b/internal/kube/client.go
@@ -100,13 +100,13 @@ func ResolveServicePorts(ctx context.Context, k kubernetes.Interface,
 		return nil, false, fmt.Errorf("endpoints store was empty")
 	}
 
-	obj, exists, err := store.GetByKey(s.Namespace + "/" + s.Name)
+	obj, _, err := store.GetByKey(s.Namespace + "/" + s.Name)
 	if err != nil {
 		return nil, false, errors.Wrap(err, "failed to get endpoints")
 	}
 
-	e := obj.(*corev1.Endpoints)
-	if !exists || len(e.Subsets) == 0 {
+	e, ok := obj.(*corev1.Endpoints)
+	if !ok || len(e.Subsets) == 0 {
 		// if there are no endpoints, don't resolve, just return them
 		servicePorts := make([]ResolvedServicePort, len(s.Spec.Ports))
 		for i, sp := range s.Spec.Ports {


### PR DESCRIPTION
Adding services while localizer was running was not working.

1. Informer caches where hardcoded to `Endpoints` objects causing errors like this:
```
DEBU[0585] pkg/mod/github.com/jaredallard/client-go@v0.0.0-20200919203213-e55c7f2b41ab/tools/cache/reflector.go:156: expected type *v1.Endpoints, but watch event object had type *v1.Service  error="<nil>" logger=klog
```
2. A panic was raised when an add event for a service was processed and the corresponding endpoints objects had not yet been synced to the cache
```
panic: interface conversion: interface {} is nil, not *v1.Endpoints

goroutine 86 [running]:
github.com/jaredallard/localizer/internal/kube.ResolveServicePorts(0x2575f40, 0xc0005a5640, 0x25a3ac0, 0xc0000ea2c0, 0xc000300fc0, 0xc000042b40, 0x28, 0x1, 0x1, 0x0, ...)
	/Users/d062284/Development/github.com/jaredallard/localizer/internal/kube/client.go:108 +0x9f
```

Signed-off-by: Fabian Ruff <fabian.ruff@sap.com>