### PR TITLE
Add environment variable to disable creation of loopback aliases (Darwin)

### DIFF
--- a/internal/proxier/portforward.go
+++ b/internal/proxier/portforward.go
@@ -19,6 +19,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"os"
 	"os/exec"
 	"runtime"
 
@@ -287,7 +288,7 @@ func (w *worker) CreatePortForward(ctx context.Context, req *CreatePortForwardRe
 
 	// We only need to create alias on darwin, on other platforms
 	// lo0 becomes lo and routes the full /8
-	if runtime.GOOS == "darwin" {
+	if runtime.GOOS == "darwin" && os.Getenv("DISABLE_LOOPBACK_ALIAS") == "" {
 		args := []string{"lo0", "alias", ipAddress.IP.String(), "up"}
 		if err := exec.Command("ifconfig", args...).Run(); err != nil {
 			return errors.Wrap(err, "failed to create ip link")
@@ -394,7 +395,7 @@ func (w *worker) stopPortForward(_ context.Context, conn *PortForwardConnection)
 	if len(conn.IP) > 0 {
 		// If we are on a platform that needs aliases
 		// then we need to remove it
-		if runtime.GOOS == "darwin" {
+		if runtime.GOOS == "darwin" && os.Getenv("DISABLE_LOOPBACK_ALIAS") == "" {
 			ipStr := conn.IP.String()
 			args := []string{"lo0", "-alias", ipStr}
 			if err := exec.Command("ifconfig", args...).Run(); err != nil {


### PR DESCRIPTION
Happy new year! 🎇
Apparently some (our) vpn clients monitor the routing table and kill the connection when modifications are detected.
Adding/removing an alias for the loopback device causes such a change to the routing table. 🙄
In our case we can prevent constant loss of vpn connectivity by preprovisioning enough™️ loopback aliases once and have localizer not dynamically create/delete them:

```
#!/bin/sh

seq 2 50| xargs -I§ ifconfig lo0 alias 127.0.0.§ up
```