### PR TITLE
fix(hostsfile): keep dns modifications made during runtime

### DIFF
--- a/pkg/hostsfile/parser.go
+++ b/pkg/hostsfile/parser.go
@@ -289,7 +289,21 @@ func (f *File) Save(ctx context.Context) error {
 		return fmt.Errorf("can't write, was not loaded from a file")
 	}
 
-	b, err := f.Marshal(ctx)
+	var b []byte
+	var err error
+	if f.fileLocation != "" {
+		f.lock.Lock()
+		// re-read the hosts file to get potential
+		// changes outside of our block
+		b, err := ioutil.ReadFile(f.fileLocation)
+		if err != nil {
+			return err
+		}
+		f.contents = b
+		f.lock.Unlock()
+	}
+
+	b, err = f.Marshal(ctx)
 	if err != nil {
 		return errors.Wrap(err, "failed to marshal hostsfile")
 	}

--- a/pkg/hostsfile/parser_test.go
+++ b/pkg/hostsfile/parser_test.go
@@ -89,13 +89,13 @@ func TestFile_Marshal(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+	f.clock = clock.NewMock()
 
 	err = f.Load(context.Background())
 	if err != nil {
 		t.Error(errors.Wrap(err, "failed to load valid hosts file"))
 	}
 
-	f.clock = clock.NewMock()
 	b, err := f.Marshal(context.Background())
 	if err != nil {
 		t.Error(errors.Wrap(err, "failed to marshal hosts file"))
@@ -111,13 +111,13 @@ func TestFile_Marshal(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+	f.clock = clock.NewMock()
 
 	err = f.Load(context.Background())
 	if err != nil {
 		t.Error(errors.Wrap(err, "failed to load valid hosts file"))
 	}
 
-	f.clock = clock.NewMock()
 	b, err = f.Marshal(context.Background())
 	if err != nil {
 		t.Error(errors.Wrap(err, "failed to marshal hosts file"))
@@ -130,6 +130,34 @@ func TestFile_Marshal(t *testing.T) {
 
 	if !reflect.DeepEqual(expected, b) {
 		t.Error("expected: ", cmp.Diff(expected, b))
+	}
+
+	// modify a hosts file outside of our library, ensure the changes
+	// are kept when Marshal'd
+	filePath = "./testdata/load/hosts-with-block.hosts"
+	f, err = New(filePath, "")
+	if err != nil {
+		t.Error(err)
+	}
+	f.clock = clock.NewMock()
+
+	err = f.Load(context.Background())
+	if err != nil {
+		t.Error(errors.Wrap(err, "failed to load valid hosts file"))
+	}
+
+	// append a new entry
+	f.contents = append([]byte(
+		"127.0.0.1 helloworld.name.io\n",
+	), f.contents...)
+
+	b, err = f.Marshal(context.Background())
+	if err != nil {
+		t.Error(errors.Wrap(err, "failed to marshal hosts file"))
+	}
+
+	if !reflect.DeepEqual(b, f.contents) {
+		t.Error("expected: ", cmp.Diff(b, f.contents))
 	}
 }
 


### PR DESCRIPTION
**What this PR does**: This PR fixes `pkg/hostsfile.Save` so that it'll keep changes made during runtime outside of the block. This is done automatically by re-reading the file right before saving.
